### PR TITLE
Switch to v3 Google Analytics

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@
 baseURL: https://flagrant.garden/
 title: Flagrant Garden
 # Google Analytics: uncomment and replace with your own code if you want to use this
-googleAnalytics: G-GBVR7XH55K
+googleAnalytics: UA-207396449-1
 
 module:
   # Dev use only! Do not uncomment unless you're modifying a theme module!


### PR DESCRIPTION
Prior analytics failed due to theme defaulting to v3 analytics
and not working with v4; see alex-shpak/hugo-book#369 for more
information.

This is possibly temporary and may require update to the UA (v4)
tag in the near future.