### PR TITLE
(MAINT) Incorporate FF dev edits

### DIFF
--- a/content/games/_index.md
+++ b/content/games/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Florp"
-description: "A d66 engine for attribute & domain games"
+title: "Games"
+description: "Tools to help players flourish"
 bookFlatSection: true
 weight: 10
 ---

--- a/content/games/factions/_index.md
+++ b/content/games/factions/_index.md
@@ -16,15 +16,27 @@ Play normally takes 30-45m for a single skirmish and works for fantasy, historic
 
 This text is open and free and always will be.
 
+<!-- Leaving the pitch text above in for now -->
+
+## Introduction
+
+This skirmish wargame is intended to:
+
++ Be used with whatever models you have on hand, in any world you choose.
++ Play out conflicts between factions on a scale of dozens (but not hundreds) of individuals.
++ Lean into scenario-based and narrative play, rather than pitched battles.
++ Explicitly support kitbashing, hacking, reuse, and modularizing.
+
 ## Requirements for Play
 
-To play this game you will need:
+To play this game, you need:
 
-* These rules.
-* Two or more players.
-* A list of Groups and their profiles.
-* Models (paper, plastic, pewter, or otherwise)—probably no more than 60 to a side.
-* Six-sided dice. More is better—you’ll be rolling 2, 3, 6, or 12 of them at a time.
-* A way to measure distance (a tape measure or ruler is probably best but a knotted string works, too).
-* A table to play on. 6’x4’ is a good area for 24-point companies. Terrain, drawn or modeled, is also useful.
-* Something to keep notes with.
++ These rules.
++ Two or more players.
++ A list of Groups and their profiles.
++ Models (paper, plastic, pewter, or otherwise), probably no more than 60 to a side.
++ Six-sided dice. More is better—you’ll often roll 2, 3, 6, or 12 of them at a time.
++ A way to measure distance (a tape measure or ruler is probably best, but a knotted string works, too).
++ A table to play on. 5’ x 3’ is a good size for 24-point companies.
+  Terrain, drawn or modeled, is also useful.
++ Paper and pencil.

--- a/content/games/factions/companies.md
+++ b/content/games/factions/companies.md
@@ -5,8 +5,203 @@ bookToC: false
 weight: 50
 ---
 
-Each of these sample Companies is made up of Groups worth 24 points.
-The first entry in each Company is the Captain's Group.
-Any traits which modify the Group's profile have already been accounted for.
+Each of these sample Companies is made of Groups worth a total of 24 points.
+The Captain’s Group is the first entry in each Company.
+Any changes to the group as the result of traits are already implemented in the group’s profile.
 
-{{< companies >}}
+## Bearfolk War Party
+
+> Tall, humanoid bears with spears and the mantle of winter.
+> Fast, tough, and staunchly dedicated to one another.
+
+| Name                              |      ME      |      MI      |    MO    |  FS   |   R   |   T   | Traits                        |
+| :-------------------------------- | :----------: | :----------: | :------: | :---: | :---: | :---: | :---------------------------- |
+| **Longbraids** (Elite Cavalry, 8) | 5+ / 3+ / 5+ |      -       | 7+ / 10” |   6   |  3+   |   4   | Defiant, Reckless, Terrifying |
+| Aurorans (Heavy Foot, 6)          | 6+ / 5+ / 4+ |      -       | 5+ / 6”  |  12   |  4+   |   3   | Apprentice, Defensive         |
+| Hunters (Heavy Cavalry, 5)        | 5+ / 4+ / 5+ | 6+ / 5+ / 6” | 5+ / 10” |   6   |  4+   |   3   | Defiant, Throwers             |
+| Hunters (Heavy Cavalry,5)         | 5+ / 4+ / 5+ | 6+ / 5+ / 6” | 5+ / 10” |   6   |  4+   |   3   | Defiant, Throwers             |
+
+Apprentice (2)
+: Before the skirmish, choose three spells.
+  This Group may activate to Cast one of those three spells.
+
+Defensive
+: If this Group is not Shaken, in difficult terrain, or in cover, they may Move into a defensive formation with all models in base contact.
+  They have +1 T until the start of their next activation.
+
+Defiant
+: If this Group is not Shaken and not already in melee, when an enemy successfully activates to Attack them they may test at 7+ to meet the enemy halfway and count both Groups as attacking for to-hit rolls.
+
+Reckless
+: If this Group is not Shaken, it must activate to Attack if possible.
+
+Terrifying (2)
+: When Attacked by this Group, enemies must reroll their highest die when testing Resolve.
+
+Throwers (1)
+: If this Group does not already have a MI profile, add one at 6+ / 5+ / 6”.
+
+## Freelance Company
+
+> Veteran soldiers cut loose from the powers that bound them, they seek meaning and resources in a bloody world.
+
+| Name                                 |      ME      |      MI       |    MO    |  FS   |   R   |   T   | Traits                                 |
+| :----------------------------------- | :----------: | :-----------: | :------: | :---: | :---: | :---: | :------------------------------------- |
+| **Lancers** (Elite Cavalry, 10)      | 5+ / 3+ / 5+ |       -       | 7+ / 10” |   6   |  3+   |   4   | Defiant, Reckless, Undead-Foe, Vicious |
+| Mounted Crossbows (Light Cavalry, 6) | 7+ / 5+ / 6  | 6+ / 5+ / 12” | 5+ / 12” |   6   |  5+   |   3   | -                                      |
+| Shieldkin (Heavy Foot, 5)            | 6+ / 5+ / 4+ |       -       | 5+ / 6”  |  12   |  4+   |   3   | Defensive, Well-Armed                  |
+| Shieldkin (Heavy Foot, 5)            | 6+ / 5+ / 4+ |       -       | 5+ / 6”  |  12   |  4+   |   3   | Defensive, Well-Armed                  |
+
+Defensive
+: If this Group is not Shaken, in difficult terrain, or in cover, they may Move into a defensive formation with all models in base contact.
+  They have +1 T until the start of their next activation.
+
+Defiant
+: If this Group is not Shaken and not already in melee, when an enemy successfully activates to Attack them they may test at 7+ to meet the enemy halfway and count both Groups as attacking for to-hit rolls.
+
+Reckless
+: If this Group is not Shaken, it must activate to Attack if possible.
+
+Undead-Foe (1)
+: This Group gains the Reckless trait against Undead enemies.
+  If this Group is already Reckless, they automatically pass their activation to Attack those enemies instead.
+  If there are no Undead in any opposing army, ignore the point cost of this trait.
+
+Vicious (3)
+: To-hit rolls of 6 inflict two hits.
+
+Well-Armed (1)
+: Once each turn, may reroll all results of 1 on a single to-hit roll.
+
+## Necromancer’s Legion
+
+> The dead rise to the Necromancer’s call and do their bidding, held together by malefic energies.
+
+| Name                                            |      ME      |  MI   |    MO    |  FS   |   R   |   T   | Traits               |
+| :---------------------------------------------- | :----------: | :---: | :------: | :---: | :---: | :---: | :------------------- |
+| Necromancer & Revenant Knights (Elite Foot, 12) | 5+ / 3+ / 4+ |   -   | 5+ / 6”  |  12   |  3+   |   4   | Caster, Summoner     |
+| Skeleton Rex (Heavy Beast, 6)                   | 5+ / 3+ / 6  |   -   | 6+ / 10” |   6   |  3+   |   4   | Reckless, Unfeeling  |
+| Skeletal Warriors (Light Foot, 3)               | 6+ / 5+ / 4+ |   -   | 5+ / 8”  |  12   |  4+   |   2   | Defensive, Unfeeling |
+| Skeletal Warriors (Light Foot, 3)               | 6+ / 5+ / 4+ |   -   | 5+ / 8”  |  12   |  4+   |   2   | Defensive, Unfeeling |
+
+Caster (4)
+: This Group may activate to Cast any spell.
+
+Defensive
+: If this Group is not Shaken, in difficult terrain, or in cover, they may Move into a defensive formation with all models in base contact.
+  They have +1 T until the start of their next activation.
+
+Reckless
+: If the Group is not shaken, it must activate to Attack if possible
+
+Summoner (3)
+: This Group may attempt to activate on 6+ to raise an undeployed Group within 12” (and no closer than 6” to an enemy).
+  The summoned Group may attempt to activate this turn.
+
+Unfeeling (0)
+: Automatically pass when testing Resolve, but round up hits inflicted against this Group.
+
+## Automata
+
+> Cold steel made warm with sentience.
+> They fulfill their own purpose now, led by a towering Titan.
+
+| Name                              |      ME      |      MI       |   MO    |  FS   |   R   |   T   | Traits                              |
+| :-------------------------------- | :----------: | :-----------: | :-----: | :---: | :---: | :---: | :---------------------------------- |
+| Titan (Elite Foot, 5)             | 5+ / 3+ / 4+ |       -       | 5+ / 6" |  12   |  3+   |   4   | -                                   |
+| Arclight Rifles (Light Foot, 5)   | 6+ / 5+ / 4+ | 6+ / 5+ / 18” | 5+ / 8" |  12   |  4+   |   2   | Defensive, Shooters                 |
+| Arclight Blasters (Light Foot, 4) | 6+ / 5+ / 4+ | 6+ / 5+ / 6”  | 5+ / 8" |  12   |  4+   |   2   | Defensive, Throwers                 |
+| Barking Sparks (Light Foot, 5)    | 6+ / 5+ / 4+ |       -       | 5+ / 8" |  12   |  4+   |   2   | Defensive, Self-Destruct, Unfeeling |
+| Barking Sparks (Light Foot, 5)    | 6+ / 5+ / 4+ |       -       | 5+ / 8" |  12   |  4+   |   2   | Defensive, Self-Destruct, Unfeeling |
+
+Defensive
+: If this Group is not Shaken, in difficult terrain, or in cover, they may Move into a defensive formation with all models in base contact.
+  They have +1 T until the start of their next activation.
+
+Self-Destruct (2)
+: This Group may attempt to activate on 5+ to self-destruct as if Shooting everything within 6”, hitting on a 3+.
+  This Group is then Routed at the end of their activation.
+
+Shooters (2)
+: Groups without an MI profile only.
+  Add an MI profile at 6+ / 5+ / 18”.
+
+Throwers (1)
+: If this Group does not already have a MI profile, add one at 6+ / 5+ / 6”.
+
+Unfeeling (0)
+: Automatically pass when testing Resolve but round up hits inflicted against this Group.
+
+## Seafolk
+
+> Mariners, raiders from the mythic dawn.
+> They bring bronze blades and eldritch flame to scour their foes from every beach and every river.
+
+| Name                           |      ME      |      MI       |    MO    |  FS   |   R   |   T   | Traits              |
+| :----------------------------- | :----------: | :-----------: | :------: | :---: | :---: | :---: | :------------------ |
+| Bronzeclad (Elite Foot, 6)     | 5+ / 3+ / 4+ |       -       | 5+ / 6”  |  12   |  3+   |   4   | Well-Armed          |
+| Slingers (Light Foot, 5)       | 6+ / 5+ / 4+ | 6+ / 5+ / 18” | 5+ / 8”  |  12   |  4+   |   2   | Defensive, Shooters |
+| Flamebearers (Light Engine, 3) |  - / - / 6   | 6+ / 5+ / 9”  | 8+ / 4”  |   6   |  5+   |   1   | Short-Ranged        |
+| Khopeshi (Light Foot, 6)       | 6+ / 5+ / 4+ |       -       | 5+ / 8”  |  12   |  4+   |   2   | Defensive, Stealthy |
+| Wyrmkith (Light Beast, 4)      | 5+ / 4+ / 6  |       -       | 6+ / 12” |   6   |  4+   |   3   | Nimble, Reckless    |
+
+Defensive
+: If this Group is not Shaken, in difficult terrain, or in cover, they may Move into a defensive formation with all models in base contact.
+  They have +1 T until the start of their next activation.
+
+Nimble
+: This Group treats difficult terrain as normal terrain.
+
+Reckless
+: If this Group is not Shaken, it must activate to Attack if possible.
+
+Shooters (2)
+: Groups without an MI profile only.
+  Add an MI profile at 6+ / 5+ / 18”.
+
+Short-Ranged (-1)
+: Groups with an MI profile only.
+  Reduce range by half.
+
+Stealthy (3)
+: Enemies cannot Shoot this Group.
+  This Group does not block line of sight except for Groups in melee.
+
+Well-Armed (1)
+: Once each turn, may reroll all results of 1 on a single to-hit roll.
+
+## Citizen’s Defense Force
+
+> A people thrust into conflict—everyone of fighting age has taken up scrounged implements to defend their homes.
+
+| Name                                   |      ME       |      MI       |    MO    |  FS   |   R   |   T   | Traits                        |
+| :------------------------------------- | :-----------: | :-----------: | :------: | :---: | :---: | :---: | :---------------------------- |
+| First Citizens (Heavy Cavalry, 7)      | 5+ / 4+ / 5+  |       -       | 5+ / 10" |   6   |  4+   |   3   | Defiant, Unerring             |
+| Neighborhood Defenders (Light Foot, 3) | 6 + / 5+ / 4+ | 6+ / 5+ / 18" | 5+ / 8"  |  12   |  4+   |   2   | Cowardly, Defensive, Shooters |
+| Neighborhood Defenders (Light Foot, 3) | 6 + / 5+ / 4+ | 6+ / 5+ / 18" | 5+ / 8"  |  12   |  4+   |   2   | Cowardly, Defensive, Shooters |
+| Neighborhood Defenders (Light Foot, 3) | 6 + / 5+ / 4+ | 6+ / 5+ / 18" | 5+ / 8"  |  12   |  4+   |   2   | Cowardly, Defensive, Shooters |
+| Street Toughs (Light Foot, 4)          | 6 + / 5+ / 4+ |       -       | 5+ / 8"  |  12   |  4+   |   2   | Cowardly, Defensive, Vicious  |
+| Kennel Hounds (Light Beast, 4)         |  5+ / 4+ / 6  |       -       | 6+ / 12" |   6   |  4+   |   3   | Nimble, Reckless              |
+
+Cowardly (-2)
+: When testing Resolve, this Group must reroll the highest die.
+
+Defensive
+: If this Group is not Shaken, in difficult terrain, or in cover, they may Move into a defensive formation with all models in base contact.
+  They have +1 T until the start of their next activation.
+
+Defiant
+: If this Group is not Shaken and not already in melee, when an enemy successfully activates to Attack them they may test at 7+ to meet the enemy halfway and count both Groups as attacking for to-hit rolls.
+
+Nimble
+: This Group treats difficult terrain as normal terrain.
+
+Shooters (2)
+: Groups without an MI profile only.
+  Add an MI profile at 6+ / 5+ / 18”.
+
+Unerring (3)
+: Once each turn, may reroll any dice on a single to-hit roll.
+
+Vicious (3)
+: To-hit rolls of 6 inflict two hits.

--- a/content/games/factions/rules.md
+++ b/content/games/factions/rules.md
@@ -6,392 +6,440 @@ weight: 10
 
 ## Companies and Captains
 
-### Constructing Companies
+### Company Construction
 
-Each side’s army, known as their Company, is made up of two or more Groups with different abilities and weaknesses.
-Each Group is made up of some number of models.
+Each side’s army, known as their Company, consists of two or more Groups with different abilities and weaknesses.
+Each Group comprises some number of models.
 
 Each side must:
 
-* Field 2-8 Groups costing 1-12 points each, noting their profile to your opponents—the number of models in a Group doesn’t matter.
-* Spend no more than 24 points total for a standard game.
++ Field 2-8 Groups of 1-12 points each, noting their profile to your opponents—the number of models in a Group doesn’t matter.
++ Spend no more than 24 points total for a standard game.
 
-### Scaling Companies
+### Company Scale
 
 Players may agree to scale their Company points up or down from 24 (increments of 6 work well).
 Both sides should use the same number of points to construct their Companies.
 Consider using smaller tables for smaller Company sizes, and larger tables for larger Companies.
-The distances assume 28mm models, so you may want to modify the distance increments if using larger or smaller models.
+The distances listed in these rules assume 28mm models, so you may want to modify the distance increments if using larger or smaller models.
 
-### Resilience
+### Fighting Strength
 
-A Group’s ability to fight is defined by their current Resilience (R).
-R always starts at 6 or 12.
+A Group’s ability to fight is defined by their current Fighting Strength (FS).
+FS starts at 6 or 12.
 
-You must always state the current R of a Group if asked.
+The current FS of a Group is open information.
 
-Losing R represents a combination of  shock, fatigue, injury, and death in a Group, and reduces the Group’s ability to engage in the skirmish.
-When reduced to half or less of their initial R, a Group is Bloodied—they roll half as many dice to hit, and are more vulnerable to psychological statuses.
-When reduced to 0R, a Group is unable to continue participating: they’re broken or captured or slaughtered; for convenience, these rules refer to such Groups as being Routed.
+Losing FS represents a combination of shock, fatigue, injury, and death in a Group, and reduces the Group’s ability to engage in the skirmish.
+While reduced to half or less of their initial FS, a Group is Bloodied—they roll half as many dice to hit, and are more vulnerable to psychological status effects.
+When reduced to 0 FS, a Group is Routed and can no longer participate in the skirmish: they are broken, captured, or slaughtered.
 
-A useful way to express the loss of R on the table is to remove models from a Group. For example, assuming a 12R Group:
+A useful way to express the loss of FS on the table is to remove models from a Group.
+For example, assuming a Group with 12 FS:
 
-* If the Group consists of 1 model, leave it on the table until R is reduced to 0 (or the Group flees).
-* If the Group consists of 2 models, remove one model when R drops to 6 or less.
-* If the Group consists of 3 models, remove one model every time the Group loses 4R (once at 8R, and again at 4R).
-* If the Group consists of 6 models, remove one model every time the Group loses 2R.
-* If the Group consists of 12 models, remove one model every time the Group loses 1R.
-* If the Group consists of 24 models, remove two models every time the Group loses 1R.
++ If the Group consists of 1 model, leave it on the table until their FS is reduced to 0 (or the Group Routs).
++ If the Group consists of 2 models, remove one model when their FS drops to 6 or less.
++ If the Group consists of 3 models, remove one model each time the Group loses 4 FS (i.e., once at 8 FS, and again at 4 FS).
++ If the Group consists of 6 models, remove one model each time the Group loses 2 FS.
++ If the Group consists of 12 models, remove one model each time the Group loses 1 FS.
++ If the Group consists of 24 models, remove two models each time the Group loses 1 FS.
 
-> 🛠 It’s best to ensure your model count divides evenly into the R of the group, but you can have any number you please.
-> Just remember to update each Group’s R on your roster as it lowers.
+> 🛠 It is best to ensure your model count divides evenly into the FS of the group, but you can have any number you please.
+> Just remember to update each Group’s FS on their profile as it changes.
 
 ### Captains
 
 Designate one model in each Company as the Captain.
-This model is part of a Group and may not join any other Groups, does not increase the R of the Group they are in, and costs no additional points.
-Friendly Groups within 12” of the Captain’s Group have a +1 bonus when Testing Resilience, unless the Captain’s Group is Shaken.
+This model is part of a Group—the Captain may not join any other Groups, does not increase the FS of the Group they are in, and costs no additional points.
+Friendly Groups within 12” of the Captain’s Group have +1 when testing Resolve, unless the Captain’s Group is Shaken.
 
-Captains start with one trait (roll or pick from the table below):
+Captains start with one trait (roll or pick one):
 
 |  3d6  |       Trait       | Effect                                                                                                                                                        |
 | :---: | :---------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-|   3   | **Reprehensible** | After deployment, whether or not the Captain is on the table, roll 1d6 for every Group except the Captain’s. On a 1, remove that Group from play—they desert. |
-|   4   |     **Vapid**     | Captain does not grant a bonus for Groups Testing Resilience.                                                                                                 |
-|   5   |   **Blood-shy**   | Captain’s Group may not be ordered to Attack.                                                                                                                 |
-|   6   |    **Feeble**     | Captain’s Group rolls one fewer die when Attacking or Shooting.                                                                                               |
-|   7   |    **Wicked**     | When any Group within 12” fails to rally, they may lose 1R to pass instead.                                                                                   |
+|   3   | **Reprehensible** | After deployment, whether or not the Captain is on the table, roll 1d6 for every Group except the Captain’s. On a 1, they desert—remove that Group from play. |
+|   4   |     **Vapid**     | The Captain does not grant a bonus for Groups testing Resolve.                                                                                                |
+|   5   |   **Blood-shy**   | The Captain’s Group may not be ordered to Attack.                                                                                                             |
+|   6   |    **Feeble**     | The Captain’s Group rolls one fewer die when Attacking or Shooting.                                                                                           |
+|   7   |    **Wicked**     | When any Group within 12” of the Captain’s Group fails to Rally, they may lose 1 FS to pass instead.                                                          |
 |   8   |    **Shrewd**     | You may add or subtract 1 from your roll when determining attacker and defender at the start of the game.                                                     |
-|   9   |   **Resolute**    | Captain and Captain’s Group are unaffected by fear effects.                                                                                                   |
-|  10   |    **Capable**    | Once each turn, Captain’s Group may reroll one die when rolling to hit.                                                                                       |
+|   9   |   **Resolute**    | The Captain and Captain’s Group are unaffected by fear effects.                                                                                               |
+|  10   |    **Capable**    | Once each turn, the Captain’s Group may reroll one die when rolling to hit.                                                                                   |
 |  11   |  **Compelling**   | Once each turn, one Group within 12” of the Captain may reroll a failed activation test.                                                                      |
 |  12   |   **Prodding**    | Once each turn, one Group within 12” of the Captain may automatically pass a Move activation test.                                                            |
 |  13   |  **Aggressive**   | Once each turn, one Group within 12” of the Captain may automatically pass an Attack activation test.                                                         |
 |  14   |  **Projectile**   | Once each turn, one Group within 12” of the Captain may automatically pass a Shooting activation test.                                                        |
-|  15   |   **Dangerous**   | Once each turn, Captain’s Group may reroll two dice when rolling to hit.                                                                                      |
+|  15   |   **Dangerous**   | Once each turn, the Captain’s Group may reroll two dice when rolling to hit.                                                                                  |
 |  16   |    **Calming**    | Once each turn, one Group within 12” of the Captain may ignore a compulsory activation as the result of the Reckless trait.                                   |
-|  17   |    **Abjured**    | Captain’s Group cannot be targeted by enemies’ spells.                                                                                                        |
-|  18   |  **Incredible**   | Once each turn, Captain’s Group may reroll three dice when rolling to hit.                                                                                    |
+|  17   |    **Abjured**    | The Captain’s Group cannot be targeted by enemies’ spells.                                                                                                    |
+|  18   |  **Incredible**   | Once each turn, the Captain’s Group may reroll three dice when rolling to hit.                                                                                |
 
 ### Group Profiles
 
-The Groups listed here are archetypes meant to fill particular roles—especially with further customization.
+The Groups below are archetypes meant to fill particular roles—especially with further customization.
 They are not so specific as to be tied to any one concept beyond those roles.
-They include: Beast, Cavalry, Foot, Missile, and Engine types, with Elite, Heavy, and Light variants.
+The archetypes include: Beast, Cavalry, Foot, Missile, and Engine types, with Elite, Heavy, and Light variants.
 
-#### Profile Values
+#### Basic Profiles
 
 Name
-: The type and variant of the Group, followed by their base cost in parentheses.
+: The name of the Group, its base cost in parentheses.
 
 Melee (ME)
-: The minimum roll required to activate the Group to Attack or Retreat, followed by the minimum result to hit an enemy when attacking, and the minimum result to hit when defending.
+: The minimum activation roll to Attack or Retreat, the minimum result to hit an enemy when attacking, the minimum result to hit when defending.
 
 Move (MO)
-: The minimum roll required to activate the Group to Move, followed by the maximum distance in inches they may Move if successful.
+: The minimum activation roll to Move, the maximum distance they may Move if successful.
 
 Missile (MI)
-: The minimum roll required to activate the Group to Shoot, followed by the minimum result to hit an enemy when Shooting, followed by the maximum Range when Shooting.
+: The minimum activation roll to Shoot, the minimum result to hit an enemy when Shooting, the maximum range when Shooting.
 
-Resilience (R)
-: The initial fighting strength of the Group, followed by the minimum result to pass when Testing Resilience.
+Fighting Strength (FS)
+: The initial strength of the Group.
+
+Resolve (R)
+: The minimum result to pass when testing Resolve.
 
 Toughness (T)
-: The number of simultaneous hits required to reduce the Group’s R by 1.
+: The number of simultaneous hits required to reduce the Group’s FS by 1.
 
 Traits
 : Any additional rules that apply to the Group.
 
-|       Name        |      ME      |    MO    |      MI       |    R    |   T   | Traits            |
-| :---------------: | :----------: | :------: | :-----------: | :-----: | :---: | :---------------- |
-|  Heavy Beast (6)  | 5+ / 3+ / 6  | 6+ / 10" |       -       | 6 / 3+  |   4   | Reckless          |
-|  Light Beast (4)  | 5+ / 4+ / 6  | 6+ / 12" |       -       | 6 / 4+  |   3   | Reckless, Nimble  |
-| Elite Cavalry (6) | 5+ / 3+ / 5+ | 7+ / 10" |       -       | 6 / 3+  |   4   | Reckless, Defiant |
-| Heavy Cavalry (4) | 5+ / 4+ / 5+ | 5+ / 10" |       -       | 6 / 4+  |   3   | Defiant           |
-| Light Cavalry (4) | 7+ / 5+ / 6  | 5+ / 12" | 6+ / 5+ / 12" | 6 / 5+  |   3   | -                 |
-| Elite Engine (6)  |  - / - / 5+  | 7+ / 4"  | 5+ / 4+ / 24" | 6 / 4+  |   3   | Ponderous         |
-| Heavy Engine (4)  |  - / - / 6   | 8+ / 2"  | 6+ / 5+ / 24" | 6 / 5+  |   2   | Ponderous         |
-| Light Engine (4)  |  - / - / 6   | 8+ / 4"  | 6+ / 5+ / 18" | 6 / 5+  |   1   | -                 |
-|  Elite Foot (5)   | 5+ / 3+ / 4+ | 5+ / 6"  |       -       | 12 / 3+ |   4   | -                 |
-|  Heavy Foot (4)   | 6+ / 5+ / 4+ | 5+ / 6"  |       -       | 12 / 4+ |   3   | Defensive         |
-|  Light Foot (3)   | 6+ / 5+ / 4+ | 5+ / 8"  |       -       | 12 / 4+ |   2   | Defensive         |
+|       Name        |      ME      |    MO    |      MI       |  FS   |   R   |   T   | Traits            |
+| :---------------: | :----------: | :------: | :-----------: | :---: | :---: | :---: | :---------------- |
+|  Heavy Beast (6)  | 5+ / 3+ / 6  | 6+ / 10" |       -       |   6   |  3+   |   4   | Reckless          |
+|  Light Beast (4)  | 5+ / 4+ / 6  | 6+ / 12" |       -       |   6   |  4+   |   3   | Reckless, Nimble  |
+| Elite Cavalry (6) | 5+ / 3+ / 5+ | 7+ / 10" |       -       |   6   |  3+   |   4   | Reckless, Defiant |
+| Heavy Cavalry (4) | 5+ / 4+ / 5+ | 5+ / 10" |       -       |   6   |  4+   |   3   | Defiant           |
+| Light Cavalry (4) | 7+ / 5+ / 6  | 5+ / 12" | 6+ / 5+ / 12" |   6   |  5+   |   3   | -                 |
+| Elite Engine (6)  |  - / - / 5+  | 7+ / 4"  | 5+ / 4+ / 24" |   6   |  4+   |   3   | Ponderous         |
+| Heavy Engine (4)  |  - / - / 6   | 8+ / 2"  | 6+ / 5+ / 24" |   6   |  5+   |   2   | Ponderous         |
+| Light Engine (4)  |  - / - / 6   | 8+ / 4"  | 6+ / 5+ / 18" |   6   |  5+   |   1   | -                 |
+|  Elite Foot (5)   | 5+ / 3+ / 4+ | 5+ / 6"  |       -       |  12   |  3+   |   4   | -                 |
+|  Heavy Foot (4)   | 6+ / 5+ / 4+ | 5+ / 6"  |       -       |  12   |  4+   |   3   | Defensive         |
+|  Light Foot (3)   | 6+ / 5+ / 4+ | 5+ / 8"  |       -       |  12   |  4+   |   2   | Defensive         |
 
 #### Profile Traits
 
 Defensive
-: If this Group is not Shaken, in rough ground, or in cover, they may Move into a defensive formation with all models in base contact.
-They have +1 T until they Move out of base contact.
+: If this Group is not Shaken, in difficult terrain, or in cover, they may Move into a defensive formation with all models in base contact.
+  They have +1 T until the start of their next activation.
 
 Defiant
-: If this Group is not Shaken and not already in melee,
-when an enemy successfully activates to Attack them they may test at 7+ to meet the enemy halfway and count both Groups as attacking for to-hit rolls.
+: If this Group is not Shaken and not already in melee, when an enemy successfully activates to Attack them, they may test at 7+ to meet the enemy halfway.
+  Count both Groups as attacking for to-hit rolls.
 
 Elusive
-: If this Group is not Shaken and not already in melee, when an enemy successfully activates to Attack them, they may test at 7+ to move up to half their Move distance and Shoot at that enemy.
+: If this Group is not Shaken and not already in melee, when an enemy successfully activates to Attack them, they may immediately test at 7+ to move up to half their Move distance and Shoot at that enemy.
 
 Nimble
-: This Group treats difficult terrain as normal terrain.
+: This Group treats difficult terrain as normal terrain instead.
 
 Ponderous
-: This Group treats difficult terrain as impassable terrain.
+: This Group treats difficult terrain as impassable terrain instead.
 
 Reckless
-: If this Group is not Shaken, it **must** activate to Attack if possible.
+: If this Group is not Shaken, it must activate to Attack, if possible.
 
-#### Optional Traits
+#### Special Traits
 
-Cost in points listed in parenthesis.
+When constructing a Company, you can apply any number of special traits to any qualifying Groups in the Company, on a case-by-case basis.
+The point cost of each trait is listed in parenthesis.
 
 Accurate (2)
 : Groups with an MI profile only.
-Improve the to-hit value by 1.
+  Improve this Group’s MI to-hit value by 1.
 
 Apprentice (2)
-: Before the skirmish, choose [three spells]({{< relref "#spells" >}}).
-This Group may activate to Cast one of those three spells.
+: Before the first turn of the skirmish, choose three spells.
+  This Group may activate to Cast one of those three spells.
 
 Caster (4)
-: This Group may activate to [Cast any spell]({{< relref "#spells" >}}).
+: This Group may activate to Cast any spell.
 
 Chariot (2)
 : Cavalry only.
-+1T, but treats difficult terrain as impassable terrain.
+  +1 T.
+  Treats difficult terrain as impassable terrain.
 
 Composed (2)
 : Groups with the Reckless trait only.
-Remove Reckless, improve MO activation by one.
+  Remove Reckless.
+  Improve MO activation by one.
 
 Cowardly (-2)
-: When Testing Resilience, this Group must always reroll the highest die.
+: When testing Resolve, this Group must reroll the highest die.
 
-\[Kind\]-Foe (1)
+\[Type\]-Foe (1)
 : Choose an enemy type.
-This Group gains the Reckless trait against those enemies.
-If this Group is already Reckless, they automatically activate to Attack those enemies instead.
-If the chosen enemy type is not in any enemy Company, ignore the point cost of this trait.
+  This Group gains the Reckless trait against those enemies.
+  If this Group is already Reckless, they must activate to Attack those enemies, if possible.
+  If the chosen enemy type is not in any enemy Company, ignore the point cost of this trait.
 
-\[Kind\]bane (4)
+\[Type\]bane (4)
 : Choose an enemy type.
-The Group ignores the Terrifying trait for those enemies, and may reroll each to-hit die once each turn when fighting them.
-If the chosen enemy type is not in any opposing army, ignore the point cost of this trait.
+  This Group ignores the Terrifying trait for those enemies, and may reroll each to-hit die once each turn when fighting them.
+  If the chosen enemy type is not in any opposing army, ignore the point cost of this trait.
 
 Move Freely (2)
 : This Group ignores all friends, enemies, and terrain while Moving.
+  Cannot end movement overlapping with other models.
 
 Offensive (2)
 : Groups with the Defensive trait only.
-Remove Defensive, improve ME to-hit by 1 when Attacking.
+  Remove Defensive.
+  Improve ME to-hit by 1 when Attacking.
 
 Self-Destruct (2)
-: This Group may attempt to activate on 5+ to self-destruct as if Shooting everything within 6”, hitting on a 3+.
-This Group is then Routed at the end of their activation.
+: This Group may attempt to activate on 5+ to self-destruct (as if Shooting everything within 6”, hitting on 3+).
+  At the end of an activation in which they self-destruct, this Group is Routed.
 
 Shooters (2)
 : Groups without an MI profile only.
-Add an MI profile at 6+ / 5+ / 18”.
+  Add an MI profile at 6+ / 5+ / 18”.
 
 Short-Ranged (-1)
 : Groups with an MI profile only.
-Reduce Range by half.
+  Reduce range by half.
 
 Stealthy (3)
 : Enemies cannot Shoot this Group.
-This Group does not block line of sight except for Groups in melee.
+  This Group does not block line of sight, except for Groups in melee with them.
 
 Summoner (3)
 : This Group may attempt to activate on 6+ to summon an undeployed Group within 12” (and no closer than 6” to an enemy).
-The summoned Group may attempt to activate this turn.
+  The summoned Group may attempt to activate this turn.
 
 Terrifying (2)
-: When Attacked by this Group, enemies must reroll their highest die when Testing Resilience.
+: While being Attacked by this Group, enemies must reroll their highest die when testing Resolve.
 
 Throwers (1)
 : Groups without an MI profile only.
-Add an MI profile at 6+ / 5+ / 6”.
+  Add an MI profile at 6+ / 5+ / 6”.
 
 Unerring (3)
-: Once each turn, may reroll any dice that miss when rolling to hit.
+: Once each turn, this Group may reroll any dice that miss when rolling to hit.
 
 Unfeeling (0)
-: Automatically pass when Testing Resilience but round up hits inflicted against this Group.
+: This Group automatically passes when testing Resolve.
+  Round up hits inflicted against this Group.
 
 Vicious (3)
-: To-hit rolls of 6 inflict two hits.
+: When this Group rolls to hit, each 6 inflicts two hits instead.
 
 Well-Armed (1)
-: Once each turn, may reroll all 1s when rolling to hit.
+: Once each turn, this Group may reroll all 1s when rolling to hit.
 
 #### Spells
 
-{{< spells "core" >}}
+|    Name    | Check | Range |       Target        |              Duration              | Effect                                                                          |
+| :--------: | :---: | :---: | :-----------------: | :--------------------------------: | :------------------------------------------------------------------------------ |
+|   Prompt   |  6+   |  18”  |    Another Group    | Until the start of your next turn. | Target may reroll when attempting to activate.                                  |
+|  Embolden  |  6+   |  18”  |    Another Group    | Until the start of your next turn. | Target may reroll when testing Resolve.                                         |
+|    Heal    |  7+   |  18”  |    Another Group    |                 -                  | Target gains 1 FS, up to their maximum.                                         |
+|  Confuse   |  7+   |  18”  |    Another Group    | Until the start of your next turn. | Treat target as Shaken.                                                         |
+|  Entangle  |  7+   |  18”  |    Another Group    | Until the start of your next turn. | Target treats all terrain as difficult.                                         |
+|  Obscure   |  7+   |  18”  | Self, Another Group | Until the start of your next turn. | Target may not be Attacked or Shot at.                                          |
+| Projectile |  7+   |  18”  |    Another Group    |                 -                  | As Shoot. Hit on 4+ within 12”, or on 5+ at 12-18”.                             |
+|   Enrage   |  7+   |  18”  |    Another Group    | Until the start of your next turn. | Target may reroll any number of to-hit dice once in melee.                      |
+|  Fortify   |  7+   |  18”  |    Another Group    | Until the start of your next turn. | Target may force enemies to reroll any number of to-hit dice once against them. |
+|  Counter   |  8+   |  18”  |        Group        |                 -                  | End any Spell effect on the target as if its duration ended.                    |
 
 ## Ambitions
 
-During setup, players may secretly choose any number of different ambitions to fulfill during a skirmish.
-At the end of the game, each fulfilled ambition earns the player 1-3 VP, and each unfulfilled ambition subtracts 1 from their VP.
-Optionally, players may reveal any of their chosen ambitions, increasing the worth of each by 1.
+During setup, players may secretly choose any number of different ambitions to fulfill during the skirmish.
+At the end of the skirmish, each fulfilled ambition is worth 1-3 VP, and each unfulfilled ambition is worth -1 VP.
+Optionally, players may reveal any of their chosen ambitions before the first turn of the skirmish, increasing their worth by 1 VP.
 
-|         Ambition         |  VP   | Fulfillment Condition                                                   |
-| :----------------------: | :---: | :---------------------------------------------------------------------- |
-|    We Will Not Break     |   3   | No Group Routed.                                                        |
-|    Win Without Moving    |   3   | Captain’s Group never moved or rolled any dice at all.                  |
-|       Do Not Waver       |   3   | No more than one friendly Group was ever Shaken at the same time.       |
-| They Will Reel Before Us |   3   | Made 3+ enemy Groups be Shaken.                                         |
-| We Will Snap Their Spine |   3   | Routed the enemy Group with the highest point value in your first turn. |
+| Ambition                 |  VP   | Fulfillment Condition                                                   |
+| :----------------------- | :---: | :---------------------------------------------------------------------- |
+| We Will Not Break        |   3   | No Group in this Company Routed.                                        |
+| Win Without Moving       |   3   | Captain’s Group never moved or rolled any dice.                         |
+| Do Not Waver             |   3   | No more than one friendly Group was Shaken at the same time.            |
+| They Will Reel Before Us |   3   | Made 3+ enemy Groups become Shaken.                                     |
+| We Will Snap Their Spine |   3   | Routed the enemy Group with the highest point value on your first turn. |
 | Give Better Than We Get  |   2   | Routed more enemy Groups than Groups of your own were Routed.           |
-|  Break Even Their Anvil  |   2   | Routed the enemy Group with the highest point value.                    |
-|     Draw First Blood     |   1   | A friendly Group was the first to reduce an enemy Group’s R.            |
-|  They Will Know My Name  |   1   | Captain’s Group caused an enemy Group to be Shaken.                     |
-|  We Will All Shed Blood  |   1   | Every Group engaged in melee at least once.                             |
-|   Rain Hell Upon Them    |   1   | Made an enemy group be Shaken only by Shooting them.                    |
+| Break Even Their Anvil   |   2   | Routed the enemy Group with the highest point value.                    |
+| Draw First Blood         |   1   | A Group in this Company was first to reduce an enemy Group’s FS.        |
+| They Will Know My Name   |   1   | Captain’s Group caused an enemy Group to become Shaken.                 |
+| We Will All Shed Blood   |   1   | Every Group in this Company engaged in melee at least once.             |
+| Rain Hell Upon Them      |   1   | Made an enemy Group become Shaken during a Shoot activation.            |
 
 ## Skirmish Rules
 
 ### Setup
 
-1. Choose points total for each side (typically 24).
-2. Set up terrain.
-3. Roll or choose a scenario.
-4. Roll for Captain’s trait (or use existing trait if an established character).
-5. Players arrange themselves into two sides, as evenly as possible.
-   Roll 1d6 each to determine which side will be attackers and which will be defenders: higher result is the attacker.
+1. Choose point total for each side (typically 24), and construct Companies.
+1. Set up terrain.
+1. Roll or choose a scenario.
+1. Roll for Captain’s trait (or keep existing trait if using an established character).
+1. Players arrange themselves into two sides, as evenly as possible.
+   Each side rolls 1d6 to determine which side will be attackers and which will be defenders: the higher result is the attacker.
    Reroll ties.
-   Unless otherwise specified in the scenario, the attackers take the first turn.
-6. Deploy companies according to the scenario guidelines (each side with the same number of Company points).
-7. Choose ambitions.
-8. The active player takes their turn.
+   Unless otherwise specified in the scenario, the attackers are the active side in the first turn.
+1. Deploy companies according to the scenario guidelines.
+1. Choose ambitions.
+1. The active side takes their turn.
 
 ### General
 
-* Round down unless otherwise noted.
-* Distance and Range are measured between the closest models in each Group.
-* Facing doesn’t matter.
-* Groups on the same side (attackers or defenders) are considered friendly.
-  Groups on opposing sides are considered enemies.
++ Round down unless otherwise noted.
++ Measure Distance and Range between the closest models in each Group.
++ Facing doesn’t matter.
++ Remove Routed groups from play.
++ Groups on the same side (attackers or defenders) are friendly.
+  Groups on opposing sides are enemies.
 
 ### Terrain
 
 Difficult
-: Each inch of movement through difficult terrain costs 2” of a model’s MO instead of 1”.
+: 1” of movement through Difficult terrain costs 2” of a model’s MO instead.
 
 Obstacle
-: If a model comes into base contact with an obstacle, it stops its Move for this activation (maintaining Cohesion).
-If a model begins its Move in contact with an obstacle, it ignores the obstacle for the purposes of movement this activation.
-If a model is within 3” of an obstacle, they count as being in Cover.
+: If a model comes into base contact with an Obstacle, it stops its Move for this activation (maintaining Cohesion).
+  If a model begins its Move in contact with an Obstacle, it ignores the Obstacle for the purposes of movement this activation.
+  If a model is within 3” of an Obstacle, they are in Cover.
 
 Cover
-: Reroll all to-hit dice that hit against Groups on the opposite side of Cover.
+: Reroll any to-hit dice that hit against Groups on the opposite side of Cover.
 
 Obscuring
-: Groups cannot see past Obscuring terrain, or more than 3” into it.
+: Groups cannot see things past Obscuring terrain, or more than 3” into it.
 
 Impassable
 : Models cannot move through Impassable terrain.
 
 ### Turns
 
-The active side attempts to activate Groups until an activation is failed or they choose to end their turn.
+The active side attempts to activate Groups until they fail an activation, or they choose to end their turn.
 
-At the beginning  of each turn, in order:
+At the beginning of each turn:
 
 1. Rally Shaken Groups.
-   All Shaken friendly Groups Test Resilience to remove Shaken status.
-   If unsuccessful, the Group loses 1R and retreats; this does not end the turn.
-   All Shaken friendly Groups must test to rally, but may do so in any order.
-2. Make checks for Reckless Groups.
-   If any friendly Group with the Reckless trait is within their movement range of an enemy, they must attempt to activate to Attack an enemy Group of your choice in range.
-   If successful, Attack as normal; otherwise, they remain stationary, but this does not end the turn.
+   All Shaken friendly Groups test Resolve to remove Shaken status.
+   If unsuccessful, the Group loses 1 FS and Retreats—this does not end the turn.
+   All friendly Shaken Groups must test to Rally at the beginning of each activation, but may do so in any order.
+1. Make checks for Reckless Groups.
+   If any friendly Group with the Reckless trait is within their movement range of an enemy,they must attempt to Attack an enemy Group in range.
+   If successful, they Attack as normal.
+   Otherwise, they remain stationary, but this does not end the turn.
 
-#### Activation
-
-For each Group which did not Rally or check for Reckless:
+### Activation
 
 1. Choose a Group to activate.
+   You may not choose a group that checked for Reckless or attempted to Rally this turn.
    Each Group may activate only once each turn.
-2. Assign a valid order to the chosen Group (Move, Shoot, Attack, or any available special orders like Cast or Summon).
-3. Roll 2d6, attempting to meet or exceed the Group’s minimum activation result for their given order.
+1. Assign a valid order to the chosen Group (Move, Shoot, Attack, or any available special orders like Cast or Summon).
+1. Roll 2d6, attempting to meet or exceed the Group’s minimum activation result for their given order.
    On a success, the Group performs the chosen order.
-4. If the Group failed their activation test, end your side's turn and the next side's turn begins.
+1. If the Group failed their activation test, end your side’s turn and the next side’s turn begins.
    Otherwise, choose another friendly Group to activate, or choose to end your turn.
 
-#### Moving
+### Orders
 
-Move each model individually.
+#### Move
+
+Move each model individually, up to their Group’s MO.
 Models may not move through other models unless otherwise stated.
 
-Cohesion
-: At the end of a Move, all models in a Group must be within 3” of at least one other model in that Group, and must be at least 3” from enemy Groups (unless in melee with them).
+##### Cohesion
 
-#### Shooting
+At the end of a Move, all models in a Group must be within 3” of at least one other model in that Group, and must be at least 3” away from enemy Groups (unless in melee with them).
 
-If the activating Group has a MI profile, they may choose a Group within range that they can see to Shoot.
+#### Shoot
 
-If Bloodied, roll 6d6 to hit; else roll 12d6.
+If the activating Group has a MI profile, they may choose to Shoot an enemy Group within range that they can see.
+
+Roll 12d6 to hit, or 6d6 instead if Bloodied.
 Each die that shows a result equal to or higher than the Shooting Group’s MI value is a hit.
-For each number of hits equal to the target’s T, reduce their R by 1.
-If the target lost any R, it must Test Resilience.
+For each number of hits equal to the target’s T, reduce their FS by 1.
+If the target Group lost at least 1 FS, they must test Resolve.
 
-#### Attacking
+#### Attack
 
-If the activating Group has a ME profile, they may choose a target within their movement distance that they can see to Attack.
+If the activating Group has a ME profile, they may choose to Attack a target within their MO distance that they can see.
 
-If already in melee, the Group may attempt to activate and either Attack or Retreat.
+If a Group is in melee at the start of their Activation, they may only attempt to activate to Attack or Retreat.
 
 To Attack:
 
 1. Move as many models as possible into base contact with the defending Group.
-   * If the defending Group has the Defiant or Elusive traits, they may test to activate that trait.
-     If successful, resolve their interrupting action; otherwise, they stand still and the attack continues as normal.
-2. Both Groups try to hit each other, rolling 6d6 if Bloodied, else rolling 12d6.
-   Each die that shows a result equal to or higher than the Group’s ME to-hit target for Attacking/Defending as appropriate is a hit (Shaken Groups only hit on a 6).
-   For each number of hits equal to the enemy’s T, reduce the enemy’s R by 1.
+   + If the defending Group has the Defiant or Elusive traits, they may test to use that trait.
+     If successful, resolve their interrupting action before proceeding.
+     Otherwise, the Attack continues as normal.
+1. Both Groups try to hit each other.
+   They each roll 12d6 to hit, or 6d6 if Bloodied.
+   Each die that shows a result equal to or higher than the Group’s ME value for attacking or defending as appropriate is a hit.
+   Shaken Groups only hit on a 6.
+   For each number of hits equal to the enemy’s T, reduce the enemy’s FS by 1.
 
-#### Retreating
+#### Retreat
 
-A Group may activate to Retreat from melee or be forced to Retreat when failing while Testing Resilience.
+A Group may activate to Retreat from melee, or they may be forced to Retreat when they fail a Resolve test.
 
-The Group moves half their MO distance directly away from the cause of Retreat.
-They may not pass within 3” of any enemy Groups.
+When Retreating, the Group moves half their MO distance directly away from the cause of Retreat.
+They may not pass within 3” of any other enemy Groups.
 
-If blocked by terrain or enemy Groups, roll 1d6 vs their current R; if lower, they lose R equal to the roll and stop moving.
+If blocked by terrain or enemy Groups, roll 1d6.
+If the roll is lower than their current FS, they lose FS equal to the roll and stop moving.
 
-If any member of the Retreating Group Retreats off of the table, the entire Group counts as having Routed and is removed from play.
+If any member of a Group goes off of the table while Retreating, the entire Group Routs.
 
-### Testing Resilience
+### Special Orders
 
-Test for a specific Group immediately when they:
+#### Cast
 
-* Lose R.
-* Are attempting to Rally.
-* Become the last Group of their Company.
+If a Group has the Apprentice or Caster trait, they may choose to Cast any spell they have access to.
+To activate, they must roll at least the Check value for the spell they want to Cast.
 
-Test once for every remaining Group immediately when:
+#### Self-Destruct
 
-* The Captain's Group is Routed.
-* The Company has lost Groups worth half or more of the total points fielded by their Company.
+If a Group has the Self-Destruct trait, they may activate on a 5+ to Shoot everything within 6”, hitting on a 3+.
+At the end of an activation in which they Self-Destruct, the Group is Routed.
 
-To Test Resilience:
+#### Summon
+
+If a Group has the Summoner trait, they may activate on a 6+ to Summon an undeployed Group within 12” and no closer than 6” to an enemy.
+A Summoned Group may attempt to activate on the turn they are Summoned.
+
+### Testing Resolve
+
+Test Resolve for a specific Group immediately when they:
+
++ Lose any amount of FS.
++ Attempt to Rally.
++ Become the last Group of their Company.
+
+Test Resolve once for every remaining Group immediately when:
+
++ The Captain’s Group is Routed.
++ The Company has lost Groups worth half or more of the total points fielded by their Company.
+
+To test Resolve:
 
 1. Roll 2d6.
-2. Modify the roll:
-   * Subtract 1 from the result for each R lost (if testing due to lost R)
-   * Subtract 1 from the result if the Group’s Company has less than half of their total points still in play
-   * Add 1 to the result if the Captain’s Group is within 12”.
-3. If the final result is equal to or higher than the Group’s R rating, they succeed.
+1. Modify the roll:
+   + -1 for each FS lost (if testing due to lost FS).
+   + -1 if the Group’s Company has less than half of their total points still in play.
+   + +1 if the Captain’s Group is within 12”.
+1. If the final result is equal to or higher than the Group’s Resolve, they succeed.
 
 If successful and Rallying, the Group is no longer Shaken.
 
-If failed but the final result is greater than 0 the Group Retreats and becomes Shaken (if already Shaken, they lose 1 R instead).
-If the final result is 0 or less, the Group is Routed.
+If failed but the final result is greater than 0, the Group Retreats and becomes Shaken (if already Shaken, they lose 1 FS instead).
+If the final result is 0 or less, the Group Routs.
 
 ### Shaken Groups
 
-* Must Test Resilience to Rally at the beginning of next turn and may not activate for any other reason
-* Only hit on a 6 in melee (not when Shooting)
-* Lose 1R and Retreat when failing while Testing Resilience
+While a Group is Shaken, they:
 
-If the Captain’s Group is Shaken, none of their special rules affect play.
++ Must test Resolve to Rally at the beginning of the next friendly turn, and may not activate for any other reason.
++ Only hit on a 6 when Attacking or defending against an Attack.
++ Lose 1 FS and Retreat when they fail a Resolve test.
+
+While the Captain’s Group is Shaken, none of their special rules affect play.
 
 ### End of Game
 
-When the chosen scenario’s closing conditions are met, total VP according to the scenario guidelines to determine the winner.
+When the chosen scenario’s closing conditions are met, total VP according to the scenario guidelines.

--- a/content/games/factions/scenarios.md
+++ b/content/games/factions/scenarios.md
@@ -1,8 +1,169 @@
 ---
 title: "Scenarios"
 description: "Sample scenarios for Flagrant Factions"
-bookToC: false
 weight: 20
 ---
 
-{{< scenarios >}}
+Each scenario describes how to deploy Companies, who takes the first turn, and its conclusion conditions.
+Some scenarios also have special rules that govern them.
+
+## 0. Pitched Battle
+
+### Deployment
+
+The attackers deploy within 12” of one edge, and defenders deploy within 12” of the opposite edge.
+Each side deploys one Group at a time, alternating between sides until both sides have deployed all the Groups they intend to have on the field at the beginning of play.
+
+### First Turn
+
+Attackers may choose to go first or allow the defender to go first.
+
+### Conclusion Conditions
+
+When fewer than 5 Groups remain across all Companies, roll 1d6 at the beginning of each subsequent turn.
+If the result is higher than the number of remaining Groups across all Companies, this is the final turn.
+
+Add up the points value of enemy Groups Routed before the end of the game—the player with the highest count gains 5VP.
+In a tie, all players tied for the highest count gain 3VP.
+
+## 1. Ambush
+
+### Deployment
+
+The defenders deploy all of their Groups within 24” of the center point, then the attackers deploy all of their groups anywhere on the table, but no closer than 6” to any defending group.
+
+### First Turn
+
+Attackers go first.
+
+### Special Rules
+
+Defenders may voluntarily Move their Groups off of any table edge.
+These Groups do not count as Routed, but have instead Escaped.
+Defender Groups forced to Retreat off the table also count as Escaped instead of Routed.
+
+### Conclusion Conditions
+
+When either side has no Groups remaining in play, the skirmish ends immediately.
+Defenders gain 2 VP for every friendly Group that Escaped and 1 VP for every enemy Group Routed.
+Attackers gain 1 VP for every enemy Group whose FS is below its starting value at the end of the game (even if they Escape off the table), and 2 VP for every enemy Group Routed.
+
+## 2. Retreat
+
+### Deployment
+
+The defenders deploy 12-18” from one edge, and the attackers deploy within 8” of the same edge.
+Each side places one Group at a time, alternating between sides until both sides have deployed all the Groups they intend to have on the field at the beginning of play.
+
+### First Turn
+
+Defenders may choose to go first or allow the attackers to go first.
+After deciding, the defender must immediately test Resolve for every Group they deployed.
+Groups that fail the Resolve test begin play Shaken.
+
+### Special Rules
+
+Defenders may voluntarily Move their Groups off the table edge opposite from the deployment edge.
+These Groups do not count as Routed, but have instead Escaped.
+Defender Groups forced to Retreat off of that edge also count as Escaped instead of Routed.
+Groups that Retreat off any other edge are Routed, as normal.
+
+### Conclusion Conditions
+
+When either side has no Groups remaining in play, the skirmish ends immediately.
+Defenders gain 3 VP for each of their Groups that Escape.
+Attackers gain 2 VP for every enemy Group Routed—they gain 4 VP instead for each enemy Captain’s Group Routed.
+
+## 3. Raid
+
+### Deployment
+
+The defenders deploy their Captain’s Group and up to half of their remaining Groups within 24” of the center point (leaving the remaining Groups out of play at the beginning of play).
+Then, the attackers deploy all the Groups they intend to have on the field at the beginning of play within 12” of any edges.
+Defenders then place 6 Asset Tokens (representing barrels of wine, prize cattle, sacred stones, etc) within 24” of the center point.
+
+### First Turn
+
+Attackers may choose to go first or allow the defenders to go first.
+### Special Rules
+
+Any defending Group may attempt to activate on a 6+ to bring a not-yet-deployed Group into play within 4”.
+The defending Captain’s Group may attempt to activate on a 4+ to bring a not-yet-deployed Group into play within 8”.
+Defending Groups cannot pick up Asset Tokens.
+
+Any attacking Group in contact with an Asset Token and not in melee may attempt to activate on a 5+ to pick up the Asset.
+On a result of 12, the Group picks up the Asset and may immediately attempt to Move.
+Groups carrying an Asset Token Move at half their normal speed and may carry the Asset off any table edge.
+A Group may only hold one Asset Token at a time.
+
+### Conclusion Conditions
+
+When either side has no Groups remaining in play, the skirmish ends immediately.
+The defenders gain 2 VP for each enemy Group Routed, and 1 VP for each Asset Token still on the table (carried by a Group or not).
+The attackers gain 3 VP for each Asset Token they took off the table.
+
+## 4. Sortie
+
+### Deployment
+
+The attackers deploy all the Groups they intend to have on the field at the beginning of play, as well as three Siege Tokens representing siege works, at least 6” from any edge and no closer than 30” from the center point.
+Then the defenders deploy all the Groups they intend to have on the field at the beginning of play within 24” of the center point.
+
+### First Turn
+
+Defenders go first.
+
+### Special Rules
+
+Any defending Group in contact with a Siege Token and not in melee may attempt to activate on a 6+ to destroy the Siege Token.
+
+### Conclusion Conditions
+
+When either side has no Groups remaining in play, or when the defenders move all of their remaining Groups within 24” of the center and declare an end to their sortie, play ends immediately.
+Defenders gain 1 VP for every enemy Group Routed, 2 VP for every enemy engine Group Routed, and 4 VP for every Siege Token destroyed.
+Attackers gain 2 VP for every enemy Group Routed, 1 VP for each of their engine Groups that was not Routed, and 3 VP for every Siege Token that was not destroyed.
+
+## 5. Extraction
+
+### Deployment
+
+The attackers deploy all the Groups they intend to have on the field at the beginning of play at least 18” from the center point.
+Then the defenders deploy one Group (the Extractees) within 6” of the center point, and all the remaining Groups they intend to have on the field at the beginning of play within 12” of any edge.
+
+### First Turn
+
+The defenders must go first.
+
+### Special Rules
+
+If the Extractees Move or Retreat off the table, they have Escaped, and are not Routed.
+
+### Conclusion Conditions
+
+Play ends when the Extractees Escape or are Routed.
+Defenders gain 6 VP if the Extractees Escape and 1VP for each enemy Group Routed.
+Attackers gain 4 VP if the Extractees were Routed, and 2 VP for each other enemy Group Routed.
+
+## 6. Ritual
+
+### Deployment
+
+The defenders deploy all the Groups they intend to have on the field at the beginning of play within 24” of the center, and designate one of their Groups as the Bodyguards of the ritualists.
+Then the attackers deploy all the Groups they intend to have on the field at the beginning of play within 12” of any edges.
+
+### First Turn
+
+The attackers may choose to go first or let the defenders go first.
+
+### Special Rules
+
+The Bodyguards may not Move.
+If they would be forced to Retreat, they lose 1 FS instead.
+At the beginning of each of the defender’s turns, roll 2d6—if the result is less than the current turn number, then the ritual is completed.
+
+### Conclusion Conditions
+
+Play ends when the ritual is completed or the bodyguard Group is Routed.
+The defenders gain 6 VP if the ritual is completed, and 1 VP for each enemy Group Routed.
+The attackers gain 4 VP if the bodyguard Group is Routed.
+

--- a/content/games/factions/spells.md
+++ b/content/games/factions/spells.md
@@ -1,6 +1,7 @@
 ---
 title: "Spells"
 description: "Sample spells for Flagrant Factions"
+draft: true
 bookToC: false
 weight: 30
 ---


### PR DESCRIPTION
This PR reworks the _Flagrant Factions_ text to incorporate all of the dev edits sourced in the google doc. From this point on, the source of truth for the project is this project.

In this conversion, no additional links or shortcodes are used; as much as possible, this update keeps the text in plain markdown. After all editing is completed, we can convert to using shortcodes and make other improvements to interactivity and referability.

This PR also:

+ standardizes on using `+` for entries in unordered lists
+ standardizes on using `1.` for entries in ordered lists
+ standardizes on using semantic linefeeds for easier editing