### PR TITLE
(MAINT) Add Hugo shortcodes as snippets

### DIFF
--- a/.frontmatter/config/content/snippets/Figure.json
+++ b/.frontmatter/config/content/snippets/Figure.json
@@ -1,0 +1,118 @@
+{
+  "description": "Add a <figure> element",
+  "body": [
+    "{{<",
+    "    figure",
+    "    src=\"[[&mediaUrl]]\"",
+    "    alt=\"[[&alt]]\"",
+    "    link=\"[[link]]\"",
+    "    target=\"[[target]]\"",
+    "    rel=\"[[rel]]\"",
+    "    title=\"[[title]]\"",
+    "    caption=\"[[caption]]\"",
+    "    class=\"[[class]]\"",
+    "    height=\"[[height]]\"",
+    "    width=\"[[width]]\"",
+    "    attr=\"[[attr]]\"",
+    "    attrlink=\"[[attrlink]]\"",
+    "/>}}"
+  ],
+  "isMediaSnippet": true,
+  "fields": [
+    {
+      "name": "link",
+      "description": "Specify the destination URL if this image should be hyperlinked.",
+      "title": "Hyperlink URL",
+      "type": "string",
+      "single": true,
+      "default": "",
+      "required": false
+    },
+    {
+      "name": "target",
+      "description": "Specify the `target` attribute for the image's hyperlink.",
+      "title": "Hyperlink Target",
+      "type": "choice",
+      "choices": ["_blank", "_self", "_parent", "_top"],
+      "required": false
+    },
+    {
+      "name": "rel",
+      "description": "Specify the `rel` attribute for the image's hyperlink.",
+      "title": "Hyperlink Target",
+      "type": "choice",
+      "choices": [
+        "alternate",
+        "author",
+        "bookmark",
+        "external",
+        "help",
+        "license",
+        "next",
+        "nofollow",
+        "noopener",
+        "noreferrer",
+        "prev",
+        "search",
+        "tag"
+      ],
+      "required": false
+    },
+    {
+      "name": "title",
+      "description": "Specify the title of the image.",
+      "title": "Figure Title",
+      "type": "string",
+      "single": true,
+      "required": false
+    },
+    {
+      "name": "caption",
+      "description": "Specify the caption for the image.",
+      "title": "Figure Caption",
+      "type": "string",
+      "single": true,
+      "required": false
+    },
+    {
+      "name": "class",
+      "description": "Specify any values to include in the `class` attribute of the `figure` tag.",
+      "title": "Classes",
+      "type": "string",
+      "single": true,
+      "required": false
+    },
+    {
+      "name": "height",
+      "description": "Specify the height of the image.",
+      "title": "Image Height",
+      "type": "string",
+      "single": true,
+      "required": false
+    },
+    {
+      "name": "width",
+      "description": "Specify the width of the image for the figure.",
+      "title": "Image Width",
+      "type": "string",
+      "single": true,
+      "required": false
+    },
+    {
+      "name": "attr",
+      "description": "Specify attribution text. May include Markdown syntax.",
+      "title": "Attribution Text",
+      "type": "string",
+      "single": true,
+      "required": false
+    },
+    {
+      "name": "attrlink",
+      "description": "Specify the destination URL if the attribution text needs to be hyperlinked.",
+      "title": "Attribution Link URL",
+      "type": "string",
+      "single": true,
+      "required": false
+    }
+  ]
+}

--- a/.frontmatter/config/content/snippets/Highlight Source Code.json
+++ b/.frontmatter/config/content/snippets/Highlight Source Code.json
@@ -1,0 +1,25 @@
+{
+  "description": "Convert source code text into syntax-highlighted HTML.",
+  "body": [
+    "{{< highlight [[language]] >}}",
+    "[[&selection]]",
+    "{{< /highlight >}}"
+  ],
+  "fields": [
+    {
+      "name": "language",
+      "title": "Language",
+      "description": "Specify the name of the language to highlight the code block as.",
+      "type": "string",
+      "single": true,
+      "required": true,
+      "default": ""
+    },
+    {
+      "name": "selection",
+      "title": "Source Code",
+      "type": "string",
+      "default": "FM_SELECTED_TEXT"
+    }
+  ]
+}

--- a/.frontmatter/config/content/snippets/Hugo Parameter.json
+++ b/.frontmatter/config/content/snippets/Hugo Parameter.json
@@ -1,0 +1,14 @@
+{
+  "description": "Insert a hugo parameter's value.",
+  "body": "{{< param \"[[name]]\" />}}",
+  "fields": [
+    {
+      "name": "name",
+      "title": "Parameter Name",
+      "description": "Specify the name of a page or site parameter. It will prefer the page value over the site value. To access deeply nested parameters, use the dot syntax, like `my.nested.param`.",
+      "type": "string",
+      "single": true,
+      "required": true
+    }
+  ]
+}

--- a/.frontmatter/config/content/snippets/Permalink.json
+++ b/.frontmatter/config/content/snippets/Permalink.json
@@ -1,0 +1,14 @@
+{
+  "description": "Insert a fully-qualified permalink to another page.",
+  "body": "{{< ref \"[[path]]\" />}}",
+  "fields": [
+    {
+      "name": "path",
+      "title": "Relative Page Path",
+      "description": "Specify the relative path to another page from this one.",
+      "type": "string",
+      "single": true,
+      "required": true
+    }
+  ]
+}

--- a/.frontmatter/config/content/snippets/Relative Permalink.json
+++ b/.frontmatter/config/content/snippets/Relative Permalink.json
@@ -1,0 +1,14 @@
+{
+  "description": "Insert a site-relative permalink to another page.",
+  "body": "{{< relref \"[[path]]\" />}}",
+  "fields": [
+    {
+      "name": "path",
+      "title": "Relative Page Path",
+      "description": "Specify the relative path to another page from this one.",
+      "type": "string",
+      "single": true,
+      "required": true
+    }
+  ]
+}

--- a/.frontmatter/config/content/snippets/gist.json
+++ b/.frontmatter/config/content/snippets/gist.json
@@ -1,0 +1,22 @@
+{
+  "description": "Embed a GitHub gist.",
+  "body": "{{< gist [[username]] [[id]] />}}",
+  "fields": [
+    {
+      "name": "username",
+      "title": "Username",
+      "description": "Specify the username the gist is stored under.",
+      "type": "string",
+      "single": true,
+      "required": true
+    },
+    {
+      "name": "id",
+      "title": "Gist ID",
+      "description": "Specify the unique ID of the gist.",
+      "type": "string",
+      "single": true,
+      "required": true
+    }
+  ]
+}

--- a/.frontmatter/config/content/snippets/instagram.json
+++ b/.frontmatter/config/content/snippets/instagram.json
@@ -1,0 +1,15 @@
+{
+  "description": "Embed a photo from instagram.",
+  "body": "{{< instagram [[id]] />}}",
+  "fields": [
+    {
+      "name": "id",
+      "title": "Photo ID",
+      "description": "Specify the ID of the photo to embed.",
+      "type": "string",
+      "single": true,
+      "required": true,
+      "default": ""
+    }
+  ]
+}

--- a/.frontmatter/config/content/snippets/tweet.json
+++ b/.frontmatter/config/content/snippets/tweet.json
@@ -1,0 +1,22 @@
+{
+  "description": "Embed a tweet.",
+  "body": "{{< tweet user=\"[[handle]]\" id=\"[[id]]\" />}}",
+  "fields": [
+    {
+      "name": "handle",
+      "title": "Tweet Author's Handle",
+      "description": "Specify the tweet author's handle.",
+      "type": "string",
+      "single": true,
+      "required": true
+    },
+    {
+      "name": "id",
+      "title": "Tweet ID",
+      "description": "Specify the unique ID of the tweet.",
+      "type": "string",
+      "single": true,
+      "required": true
+    }
+  ]
+}

--- a/.frontmatter/config/content/snippets/vimeo.json
+++ b/.frontmatter/config/content/snippets/vimeo.json
@@ -1,0 +1,14 @@
+{
+  "description": "Embed a Vimeo video.",
+  "body": "{{< vimeo [[id]] />}}",
+  "fields": [
+    {
+      "name": "id",
+      "title": "Vimeo video ID",
+      "description": "Specify the unique ID of the video.",
+      "type": "string",
+      "single": true,
+      "required": true
+    }
+  ]
+}

--- a/.frontmatter/config/content/snippets/youtube.json
+++ b/.frontmatter/config/content/snippets/youtube.json
@@ -1,0 +1,31 @@
+{
+  "description": "Embed a YouTube video.",
+  "body": "{{< vimeo id=\"[[id]]\" autoplay=\"[[autoplay]]\" title=\"[[title]]\" />}}",
+  "fields": [
+    {
+      "name": "id",
+      "title": "YouTube video ID",
+      "description": "Specify the unique ID of the video.",
+      "type": "string",
+      "single": true,
+      "required": true
+    },
+    {
+      "name": "title",
+      "title": "Video Title",
+      "description": "Specify a title for the iframe the video is embedded in. This helps with accessibility.",
+      "type": "string",
+      "single": true,
+      "required": true
+    },
+    {
+      "name": "autoplay",
+      "title": "Autoplay",
+      "description": "Specify whether the video should autoplay.",
+      "type": "choice",
+      "choices": ["true", "false"],
+      "default": "false",
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
Prior to this change, the Front Matter configuration included snippets for Platen and project-specific shortcodes. This change adds the built-in Hugo shortcodes to the list as well.

- **Figure** adds an image in a `figure` tag, pulling image metadata and allowing the user to set numerous options, including making the image a hyperlink and adding attribution text.
- **Highlight Source Code** is an alternative to code fences.
- **Hugo Parameter** inserts the value of a page or site parameter. Useful for debugging.
- **Permalink** adds a fully qualified permalink to another page on the site from the relative path to its Markdown file.
- **Relative Permalink** adds a page-relative permalink to another page on the site from the relative path to its Markdown file.
- **gist** embeds a GitHub gist.
- **instagram** embeds a photo from Instagram.
- **tweet** embeds a Tweet as a specially formatted quote block.
- **vimeo** embeds a video from Vimeo.
- **YouTube** embeds a video from YouTube.