### PR TITLE
(MAINT) Reorganize Front Matter snippets

### DIFF
--- a/.frontmatter/config/content/snippets/hugo/embeds/gist.json
+++ b/.frontmatter/config/content/snippets/hugo/embeds/gist.json
@@ -1,4 +1,5 @@
 {
+  "title": "Gist",
   "description": "Embed a GitHub gist.",
   "body": "{{< gist [[username]] [[id]] />}}",
   "fields": [

--- a/.frontmatter/config/content/snippets/hugo/embeds/instagram.json
+++ b/.frontmatter/config/content/snippets/hugo/embeds/instagram.json
@@ -1,4 +1,5 @@
 {
+  "title": "Instagram",
   "description": "Embed a photo from instagram.",
   "body": "{{< instagram [[id]] />}}",
   "fields": [

--- a/.frontmatter/config/content/snippets/hugo/embeds/tweet.json
+++ b/.frontmatter/config/content/snippets/hugo/embeds/tweet.json
@@ -1,4 +1,5 @@
 {
+  "title": "Tweet",
   "description": "Embed a tweet.",
   "body": "{{< tweet user=\"[[handle]]\" id=\"[[id]]\" />}}",
   "fields": [

--- a/.frontmatter/config/content/snippets/hugo/embeds/vimeo.json
+++ b/.frontmatter/config/content/snippets/hugo/embeds/vimeo.json
@@ -1,4 +1,5 @@
 {
+  "title": "Vimeo",
   "description": "Embed a Vimeo video.",
   "body": "{{< vimeo [[id]] />}}",
   "fields": [

--- a/.frontmatter/config/content/snippets/hugo/embeds/youtube.json
+++ b/.frontmatter/config/content/snippets/hugo/embeds/youtube.json
@@ -1,4 +1,5 @@
 {
+  "title": "YouTube",
   "description": "Embed a YouTube video.",
   "body": "{{< vimeo id=\"[[id]]\" autoplay=\"[[autoplay]]\" title=\"[[title]]\" />}}",
   "fields": [

--- a/.frontmatter/config/content/snippets/hugo/figure.json
+++ b/.frontmatter/config/content/snippets/hugo/figure.json
@@ -1,4 +1,5 @@
 {
+  "title": "Figure",
   "description": "Add a <figure> element",
   "body": [
     "{{<",

--- a/.frontmatter/config/content/snippets/hugo/highlight.json
+++ b/.frontmatter/config/content/snippets/hugo/highlight.json
@@ -1,4 +1,5 @@
 {
+  "title": "Highlight Source Code Block",
   "description": "Convert source code text into syntax-highlighted HTML.",
   "body": [
     "{{< highlight [[language]] >}}",

--- a/.frontmatter/config/content/snippets/hugo/links/permalink-relative.json
+++ b/.frontmatter/config/content/snippets/hugo/links/permalink-relative.json
@@ -1,6 +1,7 @@
 {
-  "description": "Insert a fully-qualified permalink to another page.",
-  "body": "{{< ref \"[[path]]\" />}}",
+  "title": "Relative Permalink",
+  "description": "Insert a site-relative permalink to another page.",
+  "body": "{{< relref \"[[path]]\" />}}",
   "fields": [
     {
       "name": "path",

--- a/.frontmatter/config/content/snippets/hugo/links/permalink.json
+++ b/.frontmatter/config/content/snippets/hugo/links/permalink.json
@@ -1,6 +1,7 @@
 {
-  "description": "Insert a site-relative permalink to another page.",
-  "body": "{{< relref \"[[path]]\" />}}",
+  "title": "Permalink",
+  "description": "Insert a fully-qualified permalink to another page.",
+  "body": "{{< ref \"[[path]]\" />}}",
   "fields": [
     {
       "name": "path",

--- a/.frontmatter/config/content/snippets/hugo/param.json
+++ b/.frontmatter/config/content/snippets/hugo/param.json
@@ -1,4 +1,5 @@
 {
+  "title": "Hugo Parameter",
   "description": "Insert a hugo parameter's value.",
   "body": "{{< param \"[[name]]\" />}}",
   "fields": [

--- a/.frontmatter/config/content/snippets/platen/art/art-local-caption.json
+++ b/.frontmatter/config/content/snippets/platen/art/art-local-caption.json
@@ -1,7 +1,12 @@
 {
+  "title": "Art (from local media with caption)",
   "description": "Add art as a figure with a caption and an optional content warning.",
   "body": [
-    "{{< art src=\"[[&mediaUrl]]\" alt=\"[[&alt]]\" class=\"[[classes]]\" content_warning=\"[[&content_warning]]\" >}}",
+    "{{< art src=\"[[&mediaUrl]]\"",
+    "        alt=\"[[&alt]]\"",
+    "        class=\"[[classes]]\"",
+    "        content_warning=\"[[&content_warning]]\"",
+    ">}}",
     "[[&caption]]",
     "{{< /art >}}"
   ],

--- a/.frontmatter/config/content/snippets/platen/art/art-local.json
+++ b/.frontmatter/config/content/snippets/platen/art/art-local.json
@@ -1,6 +1,13 @@
 {
+  "title": "Art (from local media)",
   "description": "Add art as a figure with an optional content warning.",
-  "body": "{{< art src=\"[[&mediaUrl]]\" alt=\"[[&alt]]\" class=\"[[classes]]\" content_warning=\"[[&content_warning]]\" />}}",
+  "body": [
+    "{{< art src=\"[[&mediaUrl]]\"",
+    "        alt=\"[[&alt]]\"",
+    "        class=\"[[classes]]\"",
+    "        content_warning=\"[[&content_warning]]\"",
+    "/>}}"
+  ],
   "isMediaSnippet": true,
   "fields": [
     {

--- a/.frontmatter/config/content/snippets/platen/art/art-remote-caption.json
+++ b/.frontmatter/config/content/snippets/platen/art/art-remote-caption.json
@@ -1,7 +1,12 @@
 {
-  "description": "",
+  "title": "Art (from remote source with caption)",
+  "description": "Add art as a figure from a remote source with a caption and an optional content warning.",
   "body": [
-    "{{< art src=\\\"[[&src]]\\\" alt=\\\"[[&alt]]\\\" class=\\\"[[classes]]\\\" content_warning=\\\"[[&content_warning]]\\\" >}}",
+    "{{< art src=\"[[&src]]\"",
+    "        alt=\"[[&alt]]\"",
+    "        class=\"[[classes]]\"",
+    "        content_warning=\"[[&content_warning]]\"",
+    ">}}",
     "[[&caption]]",
     "{{< /art >}}"
   ],

--- a/.frontmatter/config/content/snippets/platen/art/art-remote.json
+++ b/.frontmatter/config/content/snippets/platen/art/art-remote.json
@@ -1,6 +1,13 @@
 {
-  "description": "",
-  "body": "{{< art src=\\\"[[&src]]\\\" alt=\\\"[[&alt]]\\\" class=\\\"[[classes]]\\\" content_warning=\\\"[[&content_warning]]\\\" />}}",
+  "title": "Art (from remote source)",
+  "description": "Add art as a figure from a remote source with an optional content warning.",
+  "body": [
+    "{{< art src=\"[[&src]]\"",
+    "        alt=\"[[&alt]]\"",
+    "        class=\"[[classes]]\"",
+    "        content_warning=\"[[&content_warning]]\"",
+    "/>}}"
+  ],
   "fields": [
     {
       "name": "src",

--- a/.frontmatter/config/content/snippets/platen/button.json
+++ b/.frontmatter/config/content/snippets/platen/button.json
@@ -1,4 +1,5 @@
 {
+  "title": "Button",
   "description": "Add a button linking to another page or external site.",
   "body": "{{< button [[ref-type]]=\"[[&url]]\" class=\"[[classes]]\" >}}[[text]]{{< /button >}}",
   "fields": [

--- a/.frontmatter/config/content/snippets/platen/columns/columns-even.json
+++ b/.frontmatter/config/content/snippets/platen/columns/columns-even.json
@@ -1,4 +1,5 @@
 {
+  "title": "Columns (even)",
   "description": "Add markdown separated into two or more columns, evenly spaced.",
   "body": [
     "{{< columns >}}",

--- a/.frontmatter/config/content/snippets/platen/columns/columns-flex.json
+++ b/.frontmatter/config/content/snippets/platen/columns/columns-flex.json
@@ -1,4 +1,5 @@
 {
+  "title": "Columns (Flexible)",
   "description": "Add markdown separated into two or more columns, with configurable sizing.",
   "body": [
     "{{< flexcolumns ratio=\"[[&ratio]]\" flattenInMobileView=\"[[flattenInMobileView]]\" >}}",

--- a/.frontmatter/config/content/snippets/platen/details.json
+++ b/.frontmatter/config/content/snippets/platen/details.json
@@ -1,4 +1,5 @@
 {
+  "title": "Details",
   "description": "Insert a collapsible panel of Markdown content with a title.",
   "body": [
     "{{< details title=\"[[title]]\" open=[[should-be-open]] >}}",

--- a/.frontmatter/config/content/snippets/platen/hint.json
+++ b/.frontmatter/config/content/snippets/platen/hint.json
@@ -1,4 +1,5 @@
 {
+  "title": "Hint",
   "description": "Add a colored callout hint/alert - info, warning, or danger.",
   "body": ["{{< hint [[type]] >}}", "[[&selection]]", "{{< /hint >}}"],
   "fields": [

--- a/.frontmatter/config/content/snippets/platen/itch.json
+++ b/.frontmatter/config/content/snippets/platen/itch.json
@@ -1,4 +1,5 @@
 {
+  "title": "Itch Embed",
   "description": "Add an embedded widget to a project on itch.io",
   "body": "{{< itchio id=\"[[id]]\" square=\"[[square]]\"  linkback=\"[[linkback]]\" dark=\"[[dark]]\" />}}",
   "fields": [

--- a/.frontmatter/config/content/snippets/platen/katex.json
+++ b/.frontmatter/config/content/snippets/platen/katex.json
@@ -1,4 +1,5 @@
 {
+  "title": "Katex",
   "description": "Insert katex to render math typesetting.",
   "body": [
     "{{< katex [[display-as-block]] class=\"[[classes]]\" >}}",

--- a/.frontmatter/config/content/snippets/platen/mermaid.json
+++ b/.frontmatter/config/content/snippets/platen/mermaid.json
@@ -1,4 +1,5 @@
 {
+  "title": "Mermaid",
   "description": "Add a chart or diagram using mermaid.js syntax",
   "body": [
     "{{< mermaid class=\"[[classes]]\" >}}",

--- a/.frontmatter/config/content/snippets/platen/section.json
+++ b/.frontmatter/config/content/snippets/platen/section.json
@@ -1,4 +1,5 @@
 {
+  "title": "Section List",
   "description": "Add links and summaries for every child page; only valid for a section (\"_index.md\") file.",
   "body": "{{< section >}}",
   "fields": []

--- a/.frontmatter/config/content/snippets/platen/tabs/list.json
+++ b/.frontmatter/config/content/snippets/platen/tabs/list.json
@@ -1,4 +1,5 @@
 {
+  "title": "Tabbed Content",
   "description": "Add a set of markdown content with two different tabs.",
   "body": [
     "{{< tabs \"[[id]]\" >}}",

--- a/.frontmatter/config/content/snippets/platen/tabs/tab.json
+++ b/.frontmatter/config/content/snippets/platen/tabs/tab.json
@@ -1,4 +1,5 @@
 {
+  "title": "New Tab",
   "description": "Add another tab to existing tabbed content; only valid in an existing tabs shortcode.",
   "body": [
     "{{< tab \"[[name]]\" >}}",


### PR DESCRIPTION
This change takes advantage of further improvements in estruyf/vscode-front-matter#412 to reorganize the snippets into folders and subfolders for easier maintenance, adding the new `title` key for each.