### PR TITLE
(MAINT) Switch to ubuntu for actions

### DIFF
--- a/.github/workflows/hugo-module-deps.yml
+++ b/.github/workflows/hugo-module-deps.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   update_hugo_modules:
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Update Hugo Modules

--- a/.github/workflows/hugo-netlify-version.yml
+++ b/.github/workflows/hugo-netlify-version.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   update_hugo_modules:
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Update Hugo Version for Netlify


### PR DESCRIPTION
There is an unresolved bug in the hugo action that prevents it from working for non-linux builds. This commit sets the actions to use Ubuntu instead of windows.